### PR TITLE
support switching between dynamic/static kdlpp lib

### DIFF
--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -40,7 +40,7 @@ if(BUILD_KDLPP)
         src/kdlpp.cpp
     )
 
-    add_library(kdlpp STATIC ${KDLPP_CXX_SOURCES})
+    add_library(kdlpp ${KDLPP_CXX_SOURCES})
     target_compile_options(kdlpp PRIVATE ${KDL_COMPILE_OPTIONS})
     target_include_directories(kdlpp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
     target_link_libraries(kdlpp PUBLIC kdl)


### PR DESCRIPTION
right now the kdlpp library is always built statically. I removed the explicit STATIC flag from the `CMakeLists.txt` so it tracks the ON/OFF state of `BUILD_SHARED_LIBS` the same as the C library.

I wasn't sure if it was intentionally that way so feel free to close this PR if it was, but I figured opening a PR with the change would be more convenient than just opening an issue.