### PR TITLE
fix cmake configuration failure in the cpp binding in some situations

### DIFF
--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -5,6 +5,11 @@ project(kdlpp CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+	# compiling with GCC or Clang requires us to add the -std=c++20 flag in some scenarios
+    set(CMAKE_REQUIRED_FLAGS "-std=c++20")
+endif()
+
 include(CheckTypeSize)
 set(CMAKE_EXTRA_INCLUDE_FILES "string_view")
 check_type_size(std::u8string_view U8STRING_VIEW LANGUAGE CXX)


### PR DESCRIPTION
In certain situations (such as when compiling ckdl with add_subdirectory in an existing project), the `check_cxx_source_compiles` checks for the C++ bindings fail, even using a compiler with good C++20 support (such as GCC 13).

This commit checks for GCC or Clang and adds the `-std=c++20` flag as necessary, to help the checks succeed.