### PR TITLE
C++ and Python Bindings: re-raise kdl_v2 parse exception if kdl_v1 parse trial still fail

### DIFF
--- a/bindings/cpp/src/kdlpp.cpp
+++ b/bindings/cpp/src/kdlpp.cpp
@@ -228,8 +228,12 @@ Document parse(std::u8string_view kdl_text, KdlVersion version)
     else if (version == KdlVersion::Any) {
         try {
             return parse(kdl_text, KdlVersion::Kdl_2);
-        } catch (ParseError const&) {
-            return parse(kdl_text, KdlVersion::Kdl_1);
+        } catch (ParseError const& ex2) {
+            try {
+                return parse(kdl_text, KdlVersion::Kdl_1);
+            } catch (ParseError const& ex1) {
+                throw ex2;
+            }
         }
     }
 

--- a/bindings/python/src/ckdl/_ckdl.pyx
+++ b/bindings/python/src/ckdl/_ckdl.pyx
@@ -1,5 +1,6 @@
 from ._libkdl cimport *
 from libc.limits cimport LLONG_MIN, LLONG_MAX
+import sys
 
 class ParseError(ValueError):
     def __init__(self, msg):
@@ -503,8 +504,12 @@ def parse(str kdl_text, *, version="any"):
     elif version in (None, 'detect', 'any'):
         try:
             return parse(kdl_text, version=2)
-        except ParseError:
-            return parse(kdl_text, version=1)
+        except ParseError as e:
+            exc_type, exc_value, tb = sys.exc_info()
+            try:
+                return parse(kdl_text, version=1)
+            except:
+                raise e.with_traceback(tb)
     else:
         raise ValueError(f"Unexpected value for version: {version}")
 


### PR DESCRIPTION
The idea is this library expect a v2 KDL document as input, but if parse fail, the library try to use v1 KDL spec to parse input document.

My idea is: if second attempt to parse document using v1 KDL spec still fails, re-throw exception found on first parse try (using v2 KDL spec) to show that this library prefer parsing v2 spec than v1