### PR TITLE
Fix undefined behavior test failures

### DIFF
--- a/src/emitter.c
+++ b/src/emitter.c
@@ -101,7 +101,7 @@ static kdl_owned_string _float_to_string(double f, kdl_float_printing_options co
 
     bool negative = f < 0.0;
     f = fabs(f);
-    int exponent = (int)floor(log10(f));
+    int exponent = f != 0.0 ? (int)floor(log10(f)) : 0;
     double exp_factor = 1.0;
     if (abs(exponent) < opts->min_exponent) {
         // don't use scientific notation

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -96,7 +96,9 @@ static size_t _refill_tokenizer(kdl_tokenizer* self)
         self->document.len = 0;
     }
     // Move whatever data is left unparsed to the top of the buffer
-    memmove(self->buffer, self->document.data, self->document.len);
+    if (self->document.len > 0) {
+        memmove(self->buffer, self->document.data, self->document.len);
+    }
     self->document.data = self->buffer;
     size_t len_available = self->buffer_size - self->document.len;
     if (len_available < MIN_BUFFER_SIZE) {


### PR DESCRIPTION
The tests currently fail under UBSan:

    $ CFLAGS=-fsanitize=undefined LDFLAGS=-fsanitize=undefined cmake -B build
    $ cmake --build build
    $ build/tests/example_doc_test_v1 2>&1 | grep 'runtime error'
    src/tokenizer.c:99:5: runtime error: null pointer passed as argument 2, which is declared to never be null
    src/emitter.c:104:20: runtime error: -inf is outside the range of representable values of type 'int'
    src/emitter.c:106:9: runtime error: negation of -2147483648 cannot be represented in type 'int'; cast to an unsigned type to negate this value to itself

The specific errors depend on whether you're using GCC or Clang, but that's three instances of undefined behavior. The first comes from passing null to `memmove()`, which does not accept null pointers (before C2y). My fix tests the length instead of the pointer so that a null pointer with a non-zero length will still trip UBSan rather than hide a bug.

The second is an overflow casting infinity to `int`, which in practice produces `INT_MIN` which then overflows `abs`. I fixed this by not computing the log of zero.