### PR TITLE
retrieving kdl::Value as std::string

### DIFF
--- a/bindings/cpp/include/kdlpp.h
+++ b/bindings/cpp/include/kdlpp.h
@@ -262,6 +262,9 @@ public:
                 } else if constexpr (std::is_same_v<T, std::u8string_view>
                     && std::is_same_v<V, std::u8string>) {
                     return T{v};
+                } else if constexpr (std::is_same_v<T, std::string>
+                    && std::is_same_v<V, std::u8string>) {
+                    return T{v.begin(), v.end()};
                 } else {
                     throw TypeError("incompatible types");
                 }


### PR DESCRIPTION
I added a case in `kdl::Value::as<T>()`, which copies the interal `std::u8string` into a regular `std::string`. The reason is that its very annoying to work with u8strings in a codebase that otherwise uses regular strings, so having the option to retrieve the value as a `std::string` would be quite nice.